### PR TITLE
Feature/rgb8 mode

### DIFF
--- a/pointgrey_camera_driver/cfg/PointGrey.cfg
+++ b/pointgrey_camera_driver/cfg/PointGrey.cfg
@@ -111,7 +111,6 @@ gen.add("brightness",         double_t, SensorLevels.RECONFIGURE_RUNNING,     "B
 
 gen.add("gamma",              double_t, SensorLevels.RECONFIGURE_RUNNING,     "Gamma expansion exponent.",                                     1.0, 0.5, 4.0)
 
-
 gen.add("saturation",         double_t, SensorLevels.RECONFIGURE_RUNNING,     "Saturation.",                                                   100.0, 0.0, 400.0)
 
 gen.add("auto_white_balance", bool_t,    SensorLevels.RECONFIGURE_RUNNING,     "Automatically change white balance", True)

--- a/pointgrey_camera_driver/cfg/PointGrey.cfg
+++ b/pointgrey_camera_driver/cfg/PointGrey.cfg
@@ -107,7 +107,10 @@ gen.add("tilt",               int_t, 	SensorLevels.RECONFIGURE_RUNNING,     "Con
 
 gen.add("brightness",         double_t, SensorLevels.RECONFIGURE_RUNNING,     "Black level offset.",				                                             0.0, 0.0, 10.0)
 
-gen.add("gamma",              double_t, SensorLevels.RECONFIGURE_RUNNING,     "Gamma expansion exponent.",				             		             1.0, 0.5, 4.0)
+gen.add("gamma",              double_t, SensorLevels.RECONFIGURE_RUNNING,     "Gamma expansion exponent.",                                     1.0, 0.5, 4.0)
+
+
+gen.add("saturation",         double_t, SensorLevels.RECONFIGURE_RUNNING,     "Saturation.",                                                   100.0, 0.0, 400.0)
 
 gen.add("auto_white_balance", bool_t,    SensorLevels.RECONFIGURE_RUNNING,     "Automatically change white balance", True)
 
@@ -127,7 +130,8 @@ gen.add("format7_y_offset", int_t, SensorLevels.RECONFIGURE_STOP,          "Vert
 codings = gen.enum([gen.const("Mono8", str_t, "mono8", ""),
                     gen.const("Mono16", str_t, "mono16", ""),
                     gen.const("Raw8", str_t, "raw8", ""),
-                    gen.const("Raw16", str_t, "raw16", "")],
+                    gen.const("Raw16", str_t, "raw16", ""),
+                    gen.const("Rgb8", str_t, "rgb8", "")],
                     "Format7 color coding methods")
 
 gen.add("format7_color_coding", str_t, SensorLevels.RECONFIGURE_STOP,      "Color coding (only for Format7 modes)",                                                       "raw8",      edit_method = codings)


### PR DESCRIPTION
Add RGB8 mode to the camera driver. In contrary to the raw image modes, the RGB8 mode allows to perform _gamma compression_ (~contrast) and  _saturation_ on the camera.