### PR TITLE
Feature/convex hull

### DIFF
--- a/pointgrey_camera_driver/include/pointgrey_camera_driver/PointGreyCamera.h
+++ b/pointgrey_camera_driver/include/pointgrey_camera_driver/PointGreyCamera.h
@@ -49,6 +49,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 //time sync
 #include "pointgrey_camera_driver/TimeSyncEKF.h"
 
+#include "TimestampCorrector.hpp"
+
 class PointGreyCamera
 {
 
@@ -176,6 +178,17 @@ public:
 
   uint getROIPosition();
 
+  void setUseConvexhullTimesync(bool useConvexhullTimesync) {
+    use_convexhull_timesync_ = useConvexhullTimesync;
+  }
+
+  double getConvexHullSwitchingTime() const {
+    return convex_hull_switching_time_;
+  }
+
+  void setConvexHullSwitchingTime(double convexHullSwitchingTime) {
+    convex_hull_switching_time_ = convexHullSwitchingTime;
+  }
 private:
 
   uint32_t serial_; ///< A variable to hold the serial number of the desired camera.
@@ -207,6 +220,9 @@ private:
   FlyCapture2::TimeStamp cumulative_timestamp_;
 
   time_sync::TimeSyncEKF timesync_;
+  sm::timing::TimestampCorrector<double> timestamp_corrector_;
+  bool use_convexhull_timesync_ = false;
+  double convex_hull_switching_time_ = 1000;
 
   /*!
   * \brief Changes the video mode of the connected camera.

--- a/pointgrey_camera_driver/include/pointgrey_camera_driver/TimestampCorrector.hpp
+++ b/pointgrey_camera_driver/include/pointgrey_camera_driver/TimestampCorrector.hpp
@@ -1,0 +1,158 @@
+#ifndef SM_TIMESTAMP_CORRECTOR
+#define SM_TIMESTAMP_CORRECTOR
+
+#include <vector>
+#include <memory>
+
+#include <exception>
+
+namespace sm {
+  namespace timing {
+    
+    /**
+     * \class TimestampCorrector
+     *
+     * An implementation of the convex hull algorithm for one-way
+     * timestamp synchronization from 
+     *
+     * L. Zhang, Z. Liu, and C. Honghui Xia,
+     * “Clock synchronization algorithms for network measurements”,
+     * in INFOCOM 2002. Twenty-First Annual Joint Conference of the
+     * IEEE Computer and Communications Societies., vol. 1. IEEE,
+     * 2002, pp. 160–169 vol.1.
+     * 
+     */
+    template<typename TIME_T>
+    class TimestampCorrector
+    {
+    public:
+      typedef TIME_T time_t;
+      
+      TimestampCorrector();
+      virtual ~TimestampCorrector();
+
+      /** 
+       * Get an estimate of the local time of a given measurement
+       * from the remote timestamp, the local timestamp, and the 
+       * previous history of timings.
+       *
+       * NOTE: this function must be called with monotonically increasing
+       *       remote timestamps. If this is not followed, an exception will
+       *       be thrown.
+       * 
+       * @param remoteTime The time of an event on the remote clock
+       * @param localTime  The timestamp that the event was received locally
+       * 
+       * @return The estimated actual local time of the event
+       */
+      time_t correctTimestamp(const time_t & remoteTime, const time_t & localTime);
+      
+      /** 
+       * Get an estimate of the local time of a given measurement
+       * from the remote timestamp, the local timestamp, and the
+       * previous history of timings.
+       * In the background, this method uses two alternating timestamp correctors
+       * between which it switches to be reactive enough to local changes.
+       *
+       * NOTE: this function must be called with monotonically increasing
+       *       remote timestamps. If this is not followed, an exception will
+       *       be thrown.
+       *
+       * @param remoteTime      The time of an event on the remote clock
+       * @param localTime       The timestamp that the event was received locally
+       * @param switchingPeriod The timespan, when the algorithm switches between
+       *                        the two internal correctors
+       *
+       * @return The estimated actual local time of the event
+       */
+      time_t correctTimestamp(const time_t & remoteTime, const time_t & localTime, const time_t & switchingPeriod);
+
+      /**
+       * Using the current best estimate of the relationship between
+       * remote and local clocks, get the local time of a remote timestamp.
+       * 
+       * @param remoteTime The time of an event on the remote clock.
+       * 
+       * @return The estimated local time of the event.
+       */
+      time_t getLocalTime(const time_t & remoteTime) const;
+
+      /** 
+       * @return The number of points in the convex hull
+       */
+      size_t convexHullSize() const { return _convexHull.size(); }
+
+      /**
+       * @return The timespan of the convex hull
+       */
+      time_t span() const;
+
+      /**
+       * Clear the points of the convex hull
+       */
+      void reset() { _convexHull.clear(); _midpointSegmentIndex = 0; }
+
+      double getSlope() const;
+      double getOffset() const;
+      
+      void printHullPoints()
+      {
+	for(unsigned i = 0u; i < _convexHull.size(); ++i)
+	  {
+	    std::cout << i << "\t" << _convexHull[i].x << "\t" << _convexHull[i].y;
+	    if(i == _midpointSegmentIndex)
+	      std::cout << " <<< Midpoint segment start";
+	    std::cout << std::endl;
+	  }
+      }
+    private:
+      
+      class Point {
+        public:
+          Point(const time_t & x, const time_t & y) : x(x), y(y) {}
+          // remote time
+          time_t x;
+          // local time
+          time_t y;
+
+        Point operator-(const Point& p) const { return Point(x - p.x, y - p.y); }
+        Point operator+(const Point& p) const { return Point(x + p.x, y + p.y); }
+        bool operator<(const Point& p) const { return x < p.x; }
+        bool operator<(const time_t& t) const { return x < t; }
+      };
+
+      /** 
+       * Is the point above the line defined by the top two points of
+       * the convex hull?
+       * 
+       * @param p the point to check
+       * 
+       * @return true if the point is above the line.
+       */
+      bool isAboveTopLine(const Point& p) const;
+
+      /** 
+       * Is the point, p, above the line defined by the points l1 and l2?
+       * 
+       * @param l1 
+       * @param l2 
+       * @param p 
+       * 
+       * @return 
+       */
+      bool isAboveLine(const Point& l1, const Point& l2, const Point& p) const;
+
+      typedef std::vector< Point > convex_hull_t;
+      convex_hull_t _convexHull;
+      std::shared_ptr<TimestampCorrector<time_t>> _pendingCorrector;
+
+      size_t _midpointSegmentIndex;
+      
+    };
+
+  } // namespace timing
+} // namespace sm
+
+#include "implementation/TimestampCorrector.hpp"
+
+#endif /* SM_TIMESTAMP_CORRECTOR */

--- a/pointgrey_camera_driver/include/pointgrey_camera_driver/implementation/TimestampCorrector.hpp
+++ b/pointgrey_camera_driver/include/pointgrey_camera_driver/implementation/TimestampCorrector.hpp
@@ -1,0 +1,194 @@
+namespace sm {
+namespace timing {
+
+template<typename T>
+TimestampCorrector<T>::TimestampCorrector() : _midpointSegmentIndex(0u) {}
+
+template<typename T>
+TimestampCorrector<T>::~TimestampCorrector() {}
+
+
+typedef std::runtime_error Exception;
+
+#define THROW_ASSERT_EXCEPTION(X, function, file, line, text) throw std::runtime_error("Assertion: " file ": " + text)
+
+#define SM_ASSERT_GE(exceptionType, value, lowerBound, message)     \
+  if((value) < (lowerBound))                        \
+    {                                 \
+      std::stringstream sm_assert_stringstream;             \
+      sm_assert_stringstream << "assert(" << #value << " >= " << #lowerBound << ") failed [" << (value) << " >= " << (lowerBound) << "]: " <<  message; \
+      THROW_ASSERT_EXCEPTION("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+#define SM_ASSERT_GT(exceptionType, value, lowerBound, message)     \
+  if((value) <= (lowerBound))                       \
+    {                                 \
+      std::stringstream sm_assert_stringstream;             \
+      sm_assert_stringstream << "assert(" << #value << " > " << #lowerBound << ") failed [" << (value) << " > " << (lowerBound) << "]: " <<  message; \
+      THROW_ASSERT_EXCEPTION("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+
+#define SM_ASSERT_LT_DBG(exceptionType, value, upperBound, message)
+#define SM_ASSERT_GT_DBG(exceptionType, value, lowerBound, message)
+#define SM_ASSERT_GE_DBG(exceptionType, value, lowerBound, message)
+#define SM_ASSERT_LE_DBG(exceptionType, value, upperBound, message)
+
+// Returns the local time
+template<typename T>
+typename TimestampCorrector<T>::time_t TimestampCorrector<T>::correctTimestamp(
+    const time_t& remoteTime, const time_t& localTime) {
+  // Make sure this point is forward in time.
+  if(!_convexHull.empty()) {
+    SM_ASSERT_GT(TimeWentBackwardsException, remoteTime, _convexHull[_convexHull.size() - 1u].x,
+                 "The correction algorithm requires that times are passed in with monotonically "
+                 "increasing remote timestamps");
+  }
+
+  const Point p(remoteTime, localTime);
+
+  // If the point is not above the top line in the stack      
+  if(!isAboveTopLine(p)) {
+    // While on the top of the stack points are above a line between two back and the new point... 
+    while(_convexHull.size() >= 2u &&
+        isAboveLine(_convexHull[_convexHull.size() - 2u], p, _convexHull[_convexHull.size() - 1u]) ) {
+      _convexHull.pop_back();
+    }
+  }
+
+  // In either case, push the new point on to the convex hull
+  _convexHull.push_back(p);
+
+  // Update the midpoint pointer...
+  if(_convexHull.size() >= 3u) {
+    T midpoint = static_cast<T>((_convexHull[0u].x + remoteTime) / 2.0);
+
+    typename convex_hull_t::iterator lbit = std::lower_bound(_convexHull.begin(),
+                                                             _convexHull.end(), midpoint);
+    _midpointSegmentIndex = lbit - _convexHull.begin() - 1u;
+    SM_ASSERT_LT_DBG(Exception, _midpointSegmentIndex, _convexHull.size() - 1u,
+                     "The computed midpoint segment is out of bounds. Elements in hull: "
+                     << _convexHull.size() << ", Start time: " << _convexHull[0u].x
+                     << ", End time: " << _convexHull[_convexHull.size() - 1u].x
+                     << ", midpoint: " << midpoint);
+
+    SM_ASSERT_GE_DBG(Exception, midpoint, _convexHull[_midpointSegmentIndex].x,
+                     "The computed midpoint is not within the midpoint segment");
+    SM_ASSERT_LE_DBG(Exception, midpoint, _convexHull[_midpointSegmentIndex + 1u].x,
+                     "The computed midpoint is not within the midpoint segment");
+  }
+  else {
+    // and if there aren't enough data points, just return the sampled local time.
+    return localTime;
+  }
+
+  return getLocalTime(remoteTime);
+
+}
+
+// Returns the local time
+template<typename T>
+typename TimestampCorrector<T>::time_t TimestampCorrector<T>::correctTimestamp(const time_t & remoteTime, const time_t & localTime, const time_t & switchingPeriod)
+{
+
+  auto correctedTime = correctTimestamp(remoteTime, localTime);
+  if(!_pendingCorrector && this->span() > switchingPeriod / 2){
+    _pendingCorrector.reset(new TimestampCorrector<T>());
+  }
+  if(_pendingCorrector){
+    _pendingCorrector->correctTimestamp(remoteTime, localTime);
+  }
+
+  if (this->span() > switchingPeriod)
+  {
+    reset();
+    _pendingCorrector->_pendingCorrector = _pendingCorrector;
+    std::swap(*_pendingCorrector, *this);
+    _pendingCorrector->_pendingCorrector.reset();
+  }
+
+  return correctedTime;
+}
+
+
+template<typename T>
+typename TimestampCorrector<T>::time_t TimestampCorrector<T>::span() const
+{
+  if (this->convexHullSize() > 2)
+  {
+    return _convexHull.back().y - _convexHull.front().y;
+  }
+  else
+  {
+    return static_cast<time_t>(0);
+  }
+}
+
+template<typename T>
+double TimestampCorrector<T>::getSlope() const {
+  SM_ASSERT_GE(NotInitializedException, _convexHull.size(), 2u,
+               "The timestamp correction requires at least two data points "
+               "before this funciton can be called");
+
+  // Get the line at the time midpoint.
+  const Point& l1 = _convexHull[_midpointSegmentIndex];
+  const Point& l2 = _convexHull[_midpointSegmentIndex + 1u];
+
+  // Look up the local timestamp.
+  return  double(l2.y - l1.y) / double(l2.x - l1.x);
+}
+
+template<typename T>
+double TimestampCorrector<T>::getOffset() const {
+  SM_ASSERT_GE(NotInitializedException, _convexHull.size(), 2u,
+               "The timestamp correction requires at least two data points "
+               "before this function can be called");
+  // Get the line at the time midpoint.
+  const Point& l1 = _convexHull[_midpointSegmentIndex];
+  const Point& l2 = _convexHull[_midpointSegmentIndex + 1u];
+  
+  // Look up the local timestamp.
+  return  double(l1.y) + (double(-l1.x) * double(l2.y - l1.y) / double(l2.x - l1.x) );
+}
+
+  
+// Get the local time from the remote time.
+template<typename T>
+typename TimestampCorrector<T>::time_t TimestampCorrector<T>::getLocalTime(
+    const time_t& remoteTime) const {
+  SM_ASSERT_GE(NotInitializedException, _convexHull.size(), 2u,
+               "The timestamp correction requires at least two data "
+               "points before this funciton can be called");
+
+  // Get the line at the time midpoint.
+  const Point& l1 = _convexHull[_midpointSegmentIndex];
+  const Point& l2 = _convexHull[_midpointSegmentIndex + 1u];
+
+  // Look up the local timestamp.
+  const double helper = static_cast<double>(l2.y - l1.y) / static_cast<double>(l2.x - l1.x);
+  const time_t local_time = static_cast<time_t>(
+          static_cast<double>(l1.y) + helper * static_cast<double>(remoteTime - l1.x));
+  return local_time;
+}
+
+template<typename T>
+bool TimestampCorrector<T>::isAboveTopLine(const Point& p) const {
+  if(_convexHull.size() < 2u) {
+    return true;
+  }
+
+  return isAboveLine(_convexHull[ _convexHull.size() - 2u],
+                     _convexHull[ _convexHull.size() - 1u],
+                     p);
+}
+
+template<typename T>
+bool TimestampCorrector<T>::isAboveLine(const Point & l1, const Point & l2, const Point & p) const {
+  const Point v1 = l2 - l1;
+  const Point v2 = p - l1;
+
+  const T determinant = v1.x * v2.y - v1.y * v2.x;
+
+  return determinant >= static_cast<T>(0.0);
+}
+
+} // namespace timing
+} // namespace sm

--- a/pointgrey_camera_driver/src/PointGreyCamera.cpp
+++ b/pointgrey_camera_driver/src/PointGreyCamera.cpp
@@ -1009,9 +1009,13 @@ void PointGreyCamera::grabImage(sensor_msgs::Image &image, const std::string &fr
 
     double device_time = cumulative_timestamp_.seconds + cumulative_timestamp_.microSeconds*1.0/kSecondToUS;
 
-    timesync_.updateFilter(device_time, local_time);
-    double updated_local_time = timesync_.getLocalTimestamp(device_time);
-
+    double updated_local_time;
+    if(use_convexhull_timesync_){
+      updated_local_time = timestamp_corrector_.correctTimestamp(device_time, local_time, convex_hull_switching_time_);
+    } else {
+      timesync_.updateFilter(device_time, local_time);
+      updated_local_time = timesync_.getLocalTimestamp(device_time);
+    }
     image.header.stamp = ros::Time(updated_local_time);
 
     // Check the bits per pixel.

--- a/pointgrey_camera_driver/src/PointGreyCamera.cpp
+++ b/pointgrey_camera_driver/src/PointGreyCamera.cpp
@@ -983,6 +983,9 @@ void PointGreyCamera::grabImage(sensor_msgs::Image &image, const std::string &fr
     Image rawImage;
     // Retrieve an image
     Error error = cam_.RetrieveBuffer(&rawImage);
+    //get receive time in local clock
+    const double local_time = ros::Time::now().toSec();
+    
     PointGreyCamera::handleError("PointGreyCamera::grabImage Failed to retrieve buffer", error);
     metadata_ = rawImage.GetMetadata();
 
@@ -1004,9 +1007,7 @@ void PointGreyCamera::grabImage(sensor_msgs::Image &image, const std::string &fr
 
     last_timestamp_ = currentTime;
 
-    //get time in local clock
     double device_time = cumulative_timestamp_.seconds + cumulative_timestamp_.microSeconds*1.0/kSecondToUS;
-    double local_time = ros::Time::now().toSec();
 
     timesync_.updateFilter(device_time, local_time);
     double updated_local_time = timesync_.getLocalTimestamp(device_time);

--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -242,7 +242,7 @@ private:
       pg_.setUseConvexhullTimesync(use_convex_hull_time_sync);
       double convex_hull_switching_time;
       pnh.param<double>("convex_hull_switching_time", convex_hull_switching_time, pg_.getConvexHullSwitchingTime());
-      pg_.setUseConvexhullTimesync(convex_hull_switching_time);
+      pg_.setConvexHullSwitchingTime(convex_hull_switching_time);
       if(use_convex_hull_time_sync) {
         NODELET_INFO("Using convex hull time synchronization algorithm with switching time %g.", pg_.getConvexHullSwitchingTime());
       }

--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -236,6 +236,19 @@ private:
     pnh.param<bool>("auto_packet_size", auto_packet_size_, true);
     pnh.param<int>("packet_delay", packet_delay_, 4000);
 
+    {
+      bool use_convex_hull_time_sync;
+      pnh.param<bool>("use_convex_hull_time_sync", use_convex_hull_time_sync, false);
+      pg_.setUseConvexhullTimesync(use_convex_hull_time_sync);
+      double convex_hull_switching_time;
+      pnh.param<double>("convex_hull_switching_time", convex_hull_switching_time, pg_.getConvexHullSwitchingTime());
+      pg_.setUseConvexhullTimesync(convex_hull_switching_time);
+      if(use_convex_hull_time_sync) {
+        NODELET_INFO("Using convex hull time synchronization algorithm with switching time %g.", pg_.getConvexHullSwitchingTime());
+      }
+    }
+
+
     // Set GigE parameters:
     pg_.setGigEParameters(auto_packet_size_, packet_size_, packet_delay_);
 


### PR DESCRIPTION
@fmina , this should be the convex hull algorithm.
To turn it on set the ROS param `use_convex_hull_time_sync` to true or change the default in the c++ to true.

Overall this is a rather dirty integration. I suggest using this branch for testing. If it really helps then I'd suggest to create a new repository for `time_sync` algorithms on which this can then depend. And we move the SM implementation there, maybe together with the TimeSyncEKF.

So far I could not find any problem with the EKF implementation after it converged. In fact it seems to reach equally low noise.

Currently I get about 7.2 ms (one USB3 HUB in between) as unobservable delay for the filtered hw clock - in case you want to consider the expected delay somewhere.