### PR TITLE
added debayered node

### DIFF
--- a/pointgrey_camera_driver/CMakeLists.txt
+++ b/pointgrey_camera_driver/CMakeLists.txt
@@ -64,6 +64,11 @@ target_link_libraries(pointgrey_list_cameras PointGreyCamera ${catkin_LIBRARIES}
 set_target_properties(pointgrey_list_cameras
                       PROPERTIES OUTPUT_NAME list_cameras PREFIX "")
 
+add_executable(debayered_camera_node src/debayered_camera_node.cpp)
+target_link_libraries(debayered_camera_node PointGreyCamera ${catkin_LIBRARIES})
+set_target_properties(debayered_camera_node
+                      PROPERTIES OUTPUT_NAME debayered_camera_node PREFIX "")
+
 install(TARGETS
   PointGreyCamera
   PointGreyCameraNodelet
@@ -71,6 +76,7 @@ install(TARGETS
   pointgrey_camera_node
   pointgrey_stereo_node
   pointgrey_list_cameras
+  debayered_camera_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/pointgrey_camera_driver/src/debayered_camera_node.cpp
+++ b/pointgrey_camera_driver/src/debayered_camera_node.cpp
@@ -1,0 +1,25 @@
+#include <nodelet/loader.h>
+#include "ros/ros.h"
+
+int main(int argc, char** argv) {
+  ros::init(argc, argv, "debayered_camera_node");
+
+  nodelet::Loader manager;  // Don't bring up the manager ROS API
+  nodelet::V_string nargv;
+  nodelet::M_string remap(ros::names::getRemappings());
+  remap["image_raw"] = ros::names::resolve("~/image_raw");
+
+  std::string nodelet_name = ros::this_node::getName();
+  
+  manager.load(nodelet_name + "PointGreyCameraNodelet",
+               "pointgrey_camera_driver/PointGreyCameraNodelet", remap, nargv);
+  ROS_INFO_STREAM("Started " << nodelet_name << "/PointGreyCameraNodelet"
+                             << " nodelet.");
+
+  manager.load(nodelet_name + "/debayer", "image_proc/debayer", remap, nargv);
+  ROS_INFO_STREAM("Started " << nodelet_name << "/debayer"
+                             << " nodelet.");
+
+  ros::spin();
+  return 0;
+}

--- a/pointgrey_camera_driver/src/debayered_camera_node.cpp
+++ b/pointgrey_camera_driver/src/debayered_camera_node.cpp
@@ -4,13 +4,13 @@
 int main(int argc, char** argv) {
   ros::init(argc, argv, "debayered_camera_node");
 
-  nodelet::Loader manager;  // Don't bring up the manager ROS API
+  nodelet::Loader manager;
   nodelet::V_string nargv;
   nodelet::M_string remap(ros::names::getRemappings());
   remap["image_raw"] = ros::names::resolve("~/image_raw");
 
   std::string nodelet_name = ros::this_node::getName();
-  
+
   manager.load(nodelet_name + "PointGreyCameraNodelet",
                "pointgrey_camera_driver/PointGreyCameraNodelet", remap, nargv);
   ROS_INFO_STREAM("Started " << nodelet_name << "/PointGreyCameraNodelet"


### PR DESCRIPTION
Now instead of running the nodelet manager + two nodelets we can just run debayered_camera_node for the chameleon. @alexmillane @helenol 
